### PR TITLE
leads : add paginated leads list with search functionality

### DIFF
--- a/app/Http/Controllers/LeadController.php
+++ b/app/Http/Controllers/LeadController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+final class LeadController
+{
+    /**
+     * Number of leads per page.
+     */
+    private const PER_PAGE = 10;
+
+    /**
+     * Display a listing of the leads.
+     */
+    public function index(Request $request): Response
+    {
+        $query = $request->user()->leads();
+
+        $this->applySearchFilter($query, $request);
+
+        $leads = $query
+            ->orderBy('created_at', 'desc')
+            ->paginate(self::PER_PAGE)
+            ->withQueryString();
+
+        return Inertia::render('leads/index', [
+            'leads' => $leads,
+            'filters' => $request->only(['search']),
+        ]);
+    }
+
+    /**
+     * Apply search filter to the query.
+     */
+    private function applySearchFilter($query, Request $request): void
+    {
+        if (! $request->has('search') || $request->string('search')->isEmpty()) {
+            return;
+        }
+
+        $searchTerm = $request->string('search')->trim();
+        $query->search($searchTerm);
+    }
+}

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Database\Factories\LeadFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+final class Lead extends Model
+{
+    /** @use HasFactory<LeadFactory> */
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'company',
+        'email',
+        'phone',
+        'user_id',
+    ];
+
+    /**
+     * Get the user that owns the lead.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Scope a query to search leads by name, email, or phone.
+     */
+    public function scopeSearch(Builder $query, string $searchTerm): Builder
+    {
+        return $query->where(function ($q) use ($searchTerm): void {
+            $q->where('name', 'like', "%{$searchTerm}%")
+                ->orWhere('email', 'like', "%{$searchTerm}%")
+                ->orWhere('phone', 'like', "%{$searchTerm}%");
+        });
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
@@ -54,5 +55,13 @@ final class User extends Authenticatable implements MustVerifyEmail
             'password' => 'hashed',
             'two_factor_confirmed_at' => 'datetime',
         ];
+    }
+
+    /**
+     * Get the leads for the user.
+     */
+    public function leads(): HasMany
+    {
+        return $this->hasMany(Lead::class);
     }
 }

--- a/database/factories/LeadFactory.php
+++ b/database/factories/LeadFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Lead;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Lead>
+ */
+final class LeadFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'company' => fake()->optional()->company(),
+            'email' => fake()->optional()->safeEmail(),
+            'phone' => fake()->optional()->phoneNumber(),
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_01_14_134702_create_leads_table.php
+++ b/database/migrations/2026_01_14_134702_create_leads_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('leads', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('company')->nullable();
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->index('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('leads');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -6,6 +6,7 @@ namespace Database\Seeders;
 
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Database\Seeders\LeadSeeder;
 use Illuminate\Database\Seeder;
 
 final class DatabaseSeeder extends Seeder
@@ -22,5 +23,7 @@ final class DatabaseSeeder extends Seeder
             'password' => 'password',
             'email_verified_at' => now(),
         ]);
+
+        $this->call(LeadSeeder::class);
     }
 }

--- a/database/seeders/LeadSeeder.php
+++ b/database/seeders/LeadSeeder.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Lead;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+final class LeadSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Get all users and create leads for each
+        $users = User::all();
+
+        if ($users->isEmpty()) {
+            return;
+        }
+
+        // Create 5-10 leads for each user
+        foreach ($users as $user) {
+            Lead::factory()
+                ->count(fake()->numberBetween(5, 10))
+                ->create([
+                    'user_id' => $user->id,
+                ]);
+        }
+    }
+}

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -30,9 +30,10 @@ import { UserMenuContent } from '@/components/user-menu-content';
 import { useInitials } from '@/hooks/use-initials';
 import { cn, isSameUrl, resolveUrl } from '@/lib/utils';
 import { dashboard } from '@/routes';
+import { index } from '@/routes/leads';
 import { type BreadcrumbItem, type NavItem, type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/react';
-import { BookOpen, Folder, LayoutGrid, Menu, Search } from 'lucide-react';
+import { BookOpen, Folder, LayoutGrid, Menu, Search, Users } from 'lucide-react';
 import AppLogo from './app-logo';
 import AppLogoIcon from './app-logo-icon';
 
@@ -41,6 +42,11 @@ const mainNavItems: NavItem[] = [
         title: 'Dashboard',
         href: dashboard(),
         icon: LayoutGrid,
+    },
+    {
+        title: 'Leads',
+        href: index(),
+        icon: Users,
     },
 ];
 

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -11,9 +11,10 @@ import {
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
 import { dashboard } from '@/routes';
+import { index } from '@/routes/leads';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
-import { BookOpen, Folder, LayoutGrid } from 'lucide-react';
+import { BookOpen, Folder, LayoutGrid, Users } from 'lucide-react';
 import AppLogo from './app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -21,6 +22,11 @@ const mainNavItems: NavItem[] = [
         title: 'Dashboard',
         href: dashboard(),
         icon: LayoutGrid,
+    },
+    {
+        title: 'Leads',
+        href: index(),
+        icon: Users,
     },
 ];
 

--- a/resources/js/components/empty-state.tsx
+++ b/resources/js/components/empty-state.tsx
@@ -1,0 +1,25 @@
+import { type LucideIcon } from 'lucide-react';
+
+interface EmptyStateProps {
+    icon: LucideIcon;
+    title: string;
+    description: string;
+}
+
+export function EmptyState({ icon: Icon, title, description }: EmptyStateProps) {
+    return (
+        <div className="flex flex-1 flex-col items-center justify-center rounded-xl border border-sidebar-border/70 p-12 dark:border-sidebar-border">
+            <div className="flex flex-col items-center gap-4 text-center">
+                <div className="flex size-16 items-center justify-center rounded-full bg-muted">
+                    <Icon className="size-8 text-muted-foreground" />
+                </div>
+                <div className="space-y-2">
+                    <h3 className="text-lg font-semibold">{title}</h3>
+                    <p className="text-muted-foreground max-w-sm text-sm">
+                        {description}
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/leads-table.tsx
+++ b/resources/js/components/leads-table.tsx
@@ -1,0 +1,79 @@
+import { type Lead } from '@/types';
+
+interface LeadsTableProps {
+    leads: Lead[];
+}
+
+export function LeadsTable({ leads }: LeadsTableProps) {
+    return (
+        <div className="overflow-x-auto">
+            <table className="w-full">
+                <thead>
+                    <tr className="border-b border-sidebar-border/70 bg-muted/50 dark:border-sidebar-border">
+                        <th className="px-6 py-3 text-left text-sm font-semibold">
+                            Name
+                        </th>
+                        <th className="px-6 py-3 text-left text-sm font-semibold">
+                            Company
+                        </th>
+                        <th className="px-6 py-3 text-left text-sm font-semibold">
+                            Email
+                        </th>
+                        <th className="px-6 py-3 text-left text-sm font-semibold">
+                            Phone
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {leads.map((lead, index) => (
+                        <tr
+                            key={lead.id}
+                            className={`border-b border-sidebar-border/70 transition-colors hover:bg-muted/50 dark:border-sidebar-border ${
+                                index === leads.length - 1 ? 'border-b-0' : ''
+                            }`}
+                        >
+                            <td className="px-6 py-4 text-sm font-medium">
+                                {lead.name}
+                            </td>
+                            <td className="px-6 py-4 text-sm text-muted-foreground">
+                                {lead.company || (
+                                    <span className="text-muted-foreground/50">
+                                        —
+                                    </span>
+                                )}
+                            </td>
+                            <td className="px-6 py-4 text-sm text-muted-foreground">
+                                {lead.email ? (
+                                    <a
+                                        href={`mailto:${lead.email}`}
+                                        className="hover:text-foreground transition-colors"
+                                    >
+                                        {lead.email}
+                                    </a>
+                                ) : (
+                                    <span className="text-muted-foreground/50">
+                                        —
+                                    </span>
+                                )}
+                            </td>
+                            <td className="px-6 py-4 text-sm text-muted-foreground">
+                                {lead.phone ? (
+                                    <a
+                                        href={`tel:${lead.phone}`}
+                                        className="hover:text-foreground transition-colors"
+                                    >
+                                        {lead.phone}
+                                    </a>
+                                ) : (
+                                    <span className="text-muted-foreground/50">
+                                        —
+                                    </span>
+                                )}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/resources/js/components/pagination.tsx
+++ b/resources/js/components/pagination.tsx
@@ -1,0 +1,95 @@
+import { Button } from '@/components/ui/button';
+import { type PaginationLink } from '@/types';
+import { Link } from '@inertiajs/react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface PaginationProps {
+    links: PaginationLink[];
+}
+
+export function Pagination({ links }: PaginationProps) {
+    if (links.length <= 3) {
+        return null;
+    }
+
+    // Remove first (previous) and last (next) from the main links array
+    const [previous, ...pageLinks] = links.slice(0, -1);
+    const next = links[links.length - 1];
+
+    return (
+        <div className="flex flex-col gap-4 border-t border-sidebar-border/70 px-6 py-4 sm:flex-row sm:items-center sm:justify-between dark:border-sidebar-border">
+            <div className="flex items-center justify-center gap-2">
+                {previous.url ? (
+                    <Button variant="outline" size="sm" asChild>
+                        <Link href={previous.url} preserveScroll>
+                            <ChevronLeft className="size-4" />
+                            <span className="hidden sm:inline">Previous</span>
+                        </Link>
+                    </Button>
+                ) : (
+                    <Button variant="outline" size="sm" disabled>
+                        <ChevronLeft className="size-4" />
+                        <span className="hidden sm:inline">Previous</span>
+                    </Button>
+                )}
+            </div>
+
+            <div className="flex items-center justify-center gap-1 overflow-x-auto">
+                {pageLinks.map((link) => {
+                    if (link.url === null) {
+                        return (
+                            <span
+                                key={link.label}
+                                className="px-2 py-1 text-sm text-muted-foreground sm:px-3"
+                                dangerouslySetInnerHTML={{
+                                    __html: link.label,
+                                }}
+                            />
+                        );
+                    }
+
+                    return link.active ? (
+                        <Button
+                            key={link.label}
+                            variant="default"
+                            size="sm"
+                            disabled
+                        >
+                            <span
+                                dangerouslySetInnerHTML={{
+                                    __html: link.label,
+                                }}
+                            />
+                        </Button>
+                    ) : (
+                        <Button key={link.label} variant="outline" size="sm" asChild>
+                            <Link href={link.url} preserveScroll>
+                                <span
+                                    dangerouslySetInnerHTML={{
+                                        __html: link.label,
+                                    }}
+                                />
+                            </Link>
+                        </Button>
+                    );
+                })}
+            </div>
+
+            <div className="flex items-center justify-center gap-2">
+                {next.url ? (
+                    <Button variant="outline" size="sm" asChild>
+                        <Link href={next.url} preserveScroll>
+                            <span className="hidden sm:inline">Next</span>
+                            <ChevronRight className="size-4" />
+                        </Link>
+                    </Button>
+                ) : (
+                    <Button variant="outline" size="sm" disabled>
+                        <span className="hidden sm:inline">Next</span>
+                        <ChevronRight className="size-4" />
+                    </Button>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/search-input.tsx
+++ b/resources/js/components/search-input.tsx
@@ -1,0 +1,40 @@
+import { Input } from '@/components/ui/input';
+import { Search, X } from 'lucide-react';
+import { type ComponentProps } from 'react';
+
+interface SearchInputProps extends Omit<ComponentProps<'input'>, 'type'> {
+    value: string;
+    onClear: () => void;
+    placeholder?: string;
+}
+
+export function SearchInput({
+    value,
+    onClear,
+    placeholder = 'Search...',
+    className,
+    ...props
+}: SearchInputProps) {
+    return (
+        <div className={`relative ${className || ''}`}>
+            <Search className="text-muted-foreground pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2" />
+            <Input
+                type="text"
+                placeholder={placeholder}
+                value={value}
+                className="pl-9 pr-9"
+                {...props}
+            />
+            {value && (
+                <button
+                    type="button"
+                    onClick={onClear}
+                    className="text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors"
+                    aria-label="Clear search"
+                >
+                    <X className="size-4" />
+                </button>
+            )}
+        </div>
+    );
+}

--- a/resources/js/hooks/use-debounced-search.ts
+++ b/resources/js/hooks/use-debounced-search.ts
@@ -1,0 +1,55 @@
+import { router } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+
+interface UseDebouncedSearchOptions {
+    initialValue?: string;
+    debounceMs?: number;
+    route: string;
+    preserveState?: boolean;
+    preserveScroll?: boolean;
+}
+
+export function useDebouncedSearch({
+    initialValue = '',
+    debounceMs = 300,
+    route,
+    preserveState = true,
+    preserveScroll = true,
+}: UseDebouncedSearchOptions) {
+    const [search, setSearch] = useState(initialValue);
+
+    useEffect(() => {
+        const timeoutId = setTimeout(() => {
+            router.get(
+                route,
+                { search: search || undefined },
+                {
+                    preserveState,
+                    preserveScroll,
+                    replace: true,
+                },
+            );
+        }, debounceMs);
+
+        return () => clearTimeout(timeoutId);
+    }, [search, route, debounceMs, preserveState, preserveScroll]);
+
+    const clearSearch = () => {
+        setSearch('');
+        router.get(
+            route,
+            {},
+            {
+                preserveState,
+                preserveScroll,
+                replace: true,
+            },
+        );
+    };
+
+    return {
+        search,
+        setSearch,
+        clearSearch,
+    };
+}

--- a/resources/js/pages/leads/index.tsx
+++ b/resources/js/pages/leads/index.tsx
@@ -1,0 +1,80 @@
+import { EmptyState } from '@/components/empty-state';
+import { LeadsTable } from '@/components/leads-table';
+import { Pagination } from '@/components/pagination';
+import { SearchInput } from '@/components/search-input';
+import { useDebouncedSearch } from '@/hooks/use-debounced-search';
+import AppLayout from '@/layouts/app-layout';
+import { index } from '@/routes/leads';
+import {
+    type BreadcrumbItem,
+    type Lead,
+    type PaginatedData,
+} from '@/types';
+import { Head } from '@inertiajs/react';
+import { Search, Users } from 'lucide-react';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Leads',
+        href: index().url,
+    },
+];
+
+interface LeadsIndexProps {
+    leads: PaginatedData<Lead>;
+    filters: {
+        search?: string;
+    };
+}
+
+export default function LeadsIndex({ leads, filters }: LeadsIndexProps) {
+    const hasLeads = leads.data.length > 0;
+    const { search, setSearch, clearSearch } = useDebouncedSearch({
+        initialValue: filters.search || '',
+        route: '/leads',
+    });
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Leads" />
+            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h1 className="text-2xl font-semibold">Leads</h1>
+                        <p className="text-muted-foreground mt-1 text-sm">
+                            {hasLeads
+                                ? `Showing ${leads.from} to ${leads.to} of ${leads.total} leads`
+                                : filters.search
+                                  ? 'No leads found matching your search'
+                                  : 'Manage your leads and contacts'}
+                        </p>
+                    </div>
+                    <SearchInput
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        onClear={clearSearch}
+                        placeholder="Search by name, email, or phone..."
+                        className="w-full sm:w-64"
+                    />
+                </div>
+
+                {!hasLeads ? (
+                    <EmptyState
+                        icon={filters.search ? Search : Users}
+                        title={filters.search ? 'No leads found' : 'No leads yet'}
+                        description={
+                            filters.search
+                                ? 'Try adjusting your search terms to find what you are looking for.'
+                                : 'Get started by adding your first lead to track and manage your contacts.'
+                        }
+                    />
+                ) : (
+                    <div className="flex flex-col overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
+                        <LeadsTable leads={leads.data} />
+                        <Pagination links={leads.links} />
+                    </div>
+                )}
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -41,3 +41,36 @@ export interface User {
     updated_at: string;
     [key: string]: unknown; // This allows for additional properties...
 }
+
+export interface Lead {
+    id: number;
+    name: string;
+    company: string | null;
+    email: string | null;
+    phone: string | null;
+    user_id: number;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface PaginationLink {
+    url: string | null;
+    label: string;
+    active: boolean;
+}
+
+export interface PaginatedData<T> {
+    data: T[];
+    current_page: number;
+    first_page_url: string;
+    from: number | null;
+    last_page: number;
+    last_page_url: string;
+    links: PaginationLink[];
+    next_page_url: string | null;
+    path: string;
+    per_page: number;
+    prev_page_url: string | null;
+    to: number | null;
+    total: number;
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\LeadController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use Laravel\Fortify\Features;
@@ -16,6 +17,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', function () {
         return Inertia::render('dashboard');
     })->name('dashboard');
+
+    Route::get('leads', [LeadController::class, 'index'])->name('leads.index');
 });
 
 require __DIR__.'/settings.php';

--- a/tests/Feature/Leads/LeadIndexTest.php
+++ b/tests/Feature/Leads/LeadIndexTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Lead;
+use App\Models\User;
+
+test('guests are redirected to the login page when accessing leads', function (): void {
+    $this->get(route('leads.index'))->assertRedirect(route('login'));
+});
+
+test('authenticated users can visit the leads index page', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('leads.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->has('leads')
+            ->has('filters'));
+});
+
+test('users can only see their own leads', function (): void {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+
+    // Create leads for both users
+    Lead::factory()->count(5)->create(['user_id' => $user1->id]);
+    Lead::factory()->count(3)->create(['user_id' => $user2->id]);
+
+    $this->actingAs($user1)
+        ->get(route('leads.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->has('leads.data', 5)
+            ->where('leads.total', 5));
+});
+
+test('leads are paginated with 10 items per page', function (): void {
+    $user = User::factory()->create();
+    Lead::factory()->count(25)->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->get(route('leads.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->has('leads.data', 10)
+            ->where('leads.per_page', 10)
+            ->where('leads.total', 25)
+            ->where('leads.current_page', 1)
+            ->where('leads.last_page', 3));
+});
+
+test('leads are ordered by created_at descending', function (): void {
+    $user = User::factory()->create();
+
+    $oldestLead = Lead::factory()->create([
+        'user_id' => $user->id,
+        'name' => 'Oldest Lead',
+        'created_at' => now()->subDays(5),
+    ]);
+
+    $newestLead = Lead::factory()->create([
+        'user_id' => $user->id,
+        'name' => 'Newest Lead',
+        'created_at' => now(),
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('leads.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->where('leads.data.0.name', 'Newest Lead')
+            ->where('leads.data.1.name', 'Oldest Lead'));
+});
+
+test('search filters leads by name', function (): void {
+    $user = User::factory()->create();
+
+    Lead::factory()->create([
+        'user_id' => $user->id,
+        'name' => 'John Doe',
+    ]);
+
+    Lead::factory()->create([
+        'user_id' => $user->id,
+        'name' => 'Jane Smith',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('leads.index', ['search' => 'John']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->has('leads.data', 1)
+            ->where('leads.data.0.name', 'John Doe')
+            ->where('filters.search', 'John'));
+});
+
+test('search filters leads by email', function (): void {
+    $user = User::factory()->create();
+
+    Lead::factory()->create([
+        'user_id' => $user->id,
+        'email' => 'john@example.com',
+    ]);
+
+    Lead::factory()->create([
+        'user_id' => $user->id,
+        'email' => 'jane@example.com',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('leads.index', ['search' => 'john@example']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->has('leads.data', 1)
+            ->where('leads.data.0.email', 'john@example.com'));
+});
+
+test('search filters leads by phone', function (): void {
+    $user = User::factory()->create();
+
+    Lead::factory()->create([
+        'user_id' => $user->id,
+        'phone' => '1234567890',
+    ]);
+
+    Lead::factory()->create([
+        'user_id' => $user->id,
+        'phone' => '9876543210',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('leads.index', ['search' => '123']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->has('leads.data', 1)
+            ->where('leads.data.0.phone', '1234567890'));
+});
+
+test('search is case insensitive', function (): void {
+    $user = User::factory()->create();
+
+    Lead::factory()->create([
+        'user_id' => $user->id,
+        'name' => 'John Doe',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('leads.index', ['search' => 'JOHN']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->has('leads.data', 1)
+            ->where('leads.data.0.name', 'John Doe'));
+});
+
+test('search with empty string returns all leads', function (): void {
+    $user = User::factory()->create();
+    Lead::factory()->count(5)->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->get(route('leads.index', ['search' => '']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->has('leads.data', 5));
+});
+
+test('search preserves query string in pagination links', function (): void {
+    $user = User::factory()->create();
+    Lead::factory()->count(15)->create([
+        'user_id' => $user->id,
+        'name' => 'John Doe',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('leads.index', ['search' => 'John']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->has('leads.links')
+            ->where('leads.links', function ($links) {
+                // Convert Collection to array if needed
+                $linksArray = is_array($links) ? $links : $links->toArray();
+
+                // Check that pagination links include search parameter
+                foreach ($linksArray as $link) {
+                    if (isset($link['url']) && $link['url'] !== null) {
+                        expect($link['url'])->toContain('search=John');
+                    }
+                }
+
+                return true;
+            }));
+});
+
+test('empty state is shown when user has no leads', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('leads.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->has('leads.data', 0)
+            ->where('leads.total', 0));
+});
+
+test('empty state is shown when search returns no results', function (): void {
+    $user = User::factory()->create();
+    Lead::factory()->create([
+        'user_id' => $user->id,
+        'name' => 'John Doe',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('leads.index', ['search' => 'NonExistent']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->has('leads.data', 0)
+            ->where('leads.total', 0)
+            ->where('filters.search', 'NonExistent'));
+});
+
+test('search trims whitespace from search term', function (): void {
+    $user = User::factory()->create();
+
+    Lead::factory()->create([
+        'user_id' => $user->id,
+        'name' => 'John Doe',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('leads.index', ['search' => '  John  ']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leads/index')
+            ->has('leads.data', 1)
+            ->where('leads.data.0.name', 'John Doe'));
+});


### PR DESCRIPTION
- Implement Lead model, migration, factory, and seeder
- Add LeadController with pagination (10/page) and server-side search
- Create reusable React components (SearchInput, EmptyState, LeadsTable, Pagination)
- Add useDebouncedSearch hook for search functionality
- Write comprehensive test suite (14 tests, 192 assertions)
- Add leads navigation to sidebar and header

<img width="1726" height="950" alt="Screenshot 2026-01-14 at 7 45 02 PM" src="https://github.com/user-attachments/assets/7430d884-6a2f-4e2e-93af-459d7aeee462" />
<img width="1426" height="551" alt="Screenshot 2026-01-14 at 7 44 41 PM" src="https://github.com/user-attachments/assets/ee388ed0-a551-4c37-a3b7-b4fb3f975d76" />
